### PR TITLE
windows2022 image template all patches

### DIFF
--- a/images/win/windows2022.json
+++ b/images/win/windows2022.json
@@ -240,6 +240,9 @@
             "type": "powershell",
             "scripts": [
                 "{{ template_dir }}/scripts/Installers/Install-WindowsUpdates.ps1",
+                "{{ template_dir }}/scripts/Installers/Install-WindowsUpdates.ps1",
+                "{{ template_dir }}/scripts/Installers/Install-WindowsUpdates.ps1",
+                "{{ template_dir }}/scripts/Installers/Install-WindowsUpdates.ps1",
                 "{{ template_dir }}/scripts/Installers/Configure-DynamicPort.ps1",
                 "{{ template_dir }}/scripts/Installers/Configure-GDIProcessHandleQuota.ps1",
                 "{{ template_dir }}/scripts/Installers/Configure-Shell.ps1",


### PR DESCRIPTION
# Description
New tool, Bug fixing, or Improvement?  
Bug Fixing
It appears that windows 2022 image has some .net patches missing
Running windows updates script multiple times will ensure patches that are dependent on patches will also get installed
3 extra times because that is what seems to have worked in another image building solution I use

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
